### PR TITLE
Add apt dependency at 1.9.0 (from community site)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,13 @@ maintainer_email "schisamo@opscode.com"
 license          "All rights reserved"
 description      "Installs/Configures opscode-dev-shim"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"
 
 # internal cookbooks
 depends "users", "~> 0.1.6"
+depends "apt", "~> 1.9.0"
 depends "platform-specific", "~> 0.0.1"
 depends "munin-stub", "~> 0.8.1"
 depends "opscode-github", "~> 0.7.0"
-
 depends "git"
 depends "perl"


### PR DESCRIPTION
Need to have the apt dep come before platform-specific otherwise we
end up with the wrong version (berks bug?) of apt and the constraint
is ignored.
