### PR TITLE
explicitly install httparty gem at an older revision

### DIFF
--- a/libraries/stub_search.rb
+++ b/libraries/stub_search.rb
@@ -5,6 +5,18 @@ if Chef::Config[:solo]
     require 'searchef'
   rescue LoadError
     run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+    # This is a workaround - until we either are able to  update chef json dependency
+    # or get a PR in to lock fauxhai to 0.11 of httparty.
+    #
+    # httparty is a requirement of fauxhai via searchef. Later
+    # versions of it (0.12.0+) require json gem 1.8; this will fail
+    # as a chef_gem because embedded chef accepts only 1.4-1.7.
+    # Since fauxhai doesn't lock in a version, if we ensure the older
+    # version of httparty is present before pulling it in, chef_gem
+    # won't cause  0.12 or later to get pulled in.
+    httparty_gem = Chef::Resource::ChefGem.new("httparty", run_context)
+    httparty_gem.version "=0.11.0"
+    httparty_gem.run_action(:install)
     Chef::Resource::ChefGem.new("searchef", run_context).run_action(:install)
     require 'searchef'
   end


### PR DESCRIPTION
fauxhai (referenced through searchef) does not pin httparty, and a
recent release of httparty introduces a dependency on json-1.8.
Unfortunately chef requires 1.4-1.7.  By explicitly installing an
earlier version of httparty we can avoid this for now.

Longer term we'll need to address this in fauxhai upstream, assuming we
can't update chef itself for compatibility with json-1.8

ping @christophermaier @seth 
